### PR TITLE
Rotate days of week when the beginning of the week is not Monday.

### DIFF
--- a/make-calendar.py
+++ b/make-calendar.py
@@ -3,9 +3,13 @@
 import calendar
 import tempfile
 
+from collections import deque
+
 HEAD = "head.tex.in"
 
 debug = False
+
+rotate_amount = 0
 
 class LatexCalendar(calendar.Calendar):
 
@@ -23,7 +27,23 @@ class LatexCalendar(calendar.Calendar):
 
         # configure calendar
         if len(args) > 2:
+            global rotate_amount
             self.setfirstweekday(int(args[2]))
+            match int(args[2]):
+                case 6:
+                    rotate_amount = 1
+                case 5:
+                    rotate_amount = 2
+                case 4:
+                    rotate_amount = 3
+                case 3:
+                    rotate_amount = 4
+                case 2:
+                    rotate_amount = 5
+                case 1:
+                    rotate_amount = 6
+                case _:
+                    rotate_amount = 0
         else:
             self.setfirstweekday(0)
 
@@ -77,7 +97,8 @@ class LatexCalendar(calendar.Calendar):
             # table header
             self.texfile.write("\\begin{calmonth}{%s}{%d}\n\hline\n" % (calendar.month_name[month], self.year))
             # table header: day names
-            days = [d[0:2] for d in calendar.day_abbr]
+            days = deque([d[0:2] for d in calendar.day_abbr])
+            days.rotate(rotate_amount)
             days[self.sun_index] = "\\textcolor{socol}{%s}" % days[self.sun_index]
             self.texfile.write("&".join(days))
             self.texfile.write("\\\\\n\hline\n")


### PR DESCRIPTION
Prior to this, the days would be rotated such that the days would be in their proper places with the designated first day of the week appearing in the leftmost column.  Unfortunately the days of the week were not rotated.  This commit fixes that problem.