### PR TITLE
Process comments

### DIFF
--- a/make-calendar.py
+++ b/make-calendar.py
@@ -3,9 +3,13 @@
 import calendar
 import tempfile
 
+from collections import deque
+
 HEAD = "head.tex.in"
 
 debug = False
+
+rotate_amount = 0
 
 class LatexCalendar(calendar.Calendar):
 
@@ -23,7 +27,23 @@ class LatexCalendar(calendar.Calendar):
 
         # configure calendar
         if len(args) > 2:
+            global rotate_amount
             self.setfirstweekday(int(args[2]))
+            match int(args[2]):
+                case 6:
+                    rotate_amount = 1
+                case 5:
+                    rotate_amount = 2
+                case 4:
+                    rotate_amount = 3
+                case 3:
+                    rotate_amount = 4
+                case 2:
+                    rotate_amount = 5
+                case 1:
+                    rotate_amount = 6
+                case _:
+                    rotate_amount = 0
         else:
             self.setfirstweekday(0)
 
@@ -77,7 +97,8 @@ class LatexCalendar(calendar.Calendar):
             # table header
             self.texfile.write("\\begin{calmonth}{%s}{%d}\n\hline\n" % (calendar.month_name[month], self.year))
             # table header: day names
-            days = [d[0:2] for d in calendar.day_abbr]
+            days = deque([d[0:2] for d in calendar.day_abbr])
+            days.rotate(rotate_amount)
             days[self.sun_index] = "\\textcolor{socol}{%s}" % days[self.sun_index]
             self.texfile.write("&".join(days))
             self.texfile.write("\\\\\n\hline\n")

--- a/make-calendar.py
+++ b/make-calendar.py
@@ -68,6 +68,12 @@ class LatexCalendar(calendar.Calendar):
                     first = False
                     continue
 
+                if len(line.strip()) == 0 :
+                    continue
+
+                if line in ['\n', '\r\n']:
+                    continue
+
                 name,date,special=line.strip().split(',')
                 m,d,_ = map(int, date.split('/'))
 

--- a/make-calendar.py
+++ b/make-calendar.py
@@ -68,8 +68,8 @@ class LatexCalendar(calendar.Calendar):
                     first = False
                     continue
 
-                date,name,special=line.strip().split(',')
-                d,m,_ = map(int, date.split('/'))
+                name,date,special=line.strip().split(',')
+                m,d,_ = map(int, date.split('/'))
 
                 if (m in self.data.keys() and d in self.data[m].keys()):
                     self.data[m][d].append((name, special))

--- a/make-calendar.py
+++ b/make-calendar.py
@@ -74,6 +74,10 @@ class LatexCalendar(calendar.Calendar):
                 if line in ['\n', '\r\n']:
                     continue
 
+                line = line.split('#',1)[0].strip()
+                if not line:
+                    continue
+
                 name,date,special=line.strip().split(',')
                 m,d,_ = map(int, date.split('/'))
 

--- a/make-calendar.py
+++ b/make-calendar.py
@@ -62,12 +62,7 @@ class LatexCalendar(calendar.Calendar):
             self.data[i]=dict()
 
         with open(filename) as datafile:
-            first = True
             for line in datafile:
-                if first:
-                    first = False
-                    continue
-
                 if len(line.strip()) == 0 :
                     continue
 


### PR DESCRIPTION
Honors `#`  as a comment character.  Removed code that ignores the first line of the `.csv` file as superfluous.  The only reason for that code that I can think of is for comments.